### PR TITLE
Removed OJ json parser

### DIFF
--- a/cropster.gemspec
+++ b/cropster.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "typhoeus"
   spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "activesupport", "> 5"
-  spec.add_runtime_dependency "oj"
   spec.add_development_dependency "bundler", "~> 2.0.2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/cropster/client.rb
+++ b/lib/cropster/client.rb
@@ -58,8 +58,7 @@ module Cropster
     #
     # @param response [Typoeus::Response]
     def data_set(response)
-      Oj.load(response.body)["data"]
-      # JSON.parse(response.body)["data"]
+      JSON.parse(response.body)["data"]
     end
 
     # Builds the filter URL from the provided options


### PR DESCRIPTION
was used when testing an issue with the JSON response from Cropster and no longer needed